### PR TITLE
Proposta de rota api para captura simples de template

### DIFF
--- a/Controllers/APIController.cs
+++ b/Controllers/APIController.cs
@@ -55,5 +55,12 @@ namespace BiometricService.Controllers
         {
             return _biometric.DeviceUniqueSerialID();
         }
+
+        [HttpGet("capture")]
+        public IActionResult Snapshot()
+        {
+            return _biometric.Snapshot();
+        }
+    }
     }
 }

--- a/Modules/Biometric.cs
+++ b/Modules/Biometric.cs
@@ -194,4 +194,28 @@ public class Biometric
         );
     }
 
+    public IActionResult Snapshot()
+    {
+        APIServiceInstance._NBioAPI.OpenDevice(NBioAPI.Type.DEVICE_ID.AUTO);
+        uint ret = APIServiceInstance._NBioAPI.Capture(NBioAPI.Type.FIR_PURPOSE.VERIFY, out NBioAPI.Type.HFIR hCapturedFIR, NBioAPI.Type.TIMEOUT.DEFAULT, null, null);
+        APIServiceInstance._NBioAPI.CloseDevice(NBioAPI.Type.DEVICE_ID.AUTO);
+        if (ret != NBioAPI.Error.NONE) return new BadRequestObjectResult(
+            new JsonObject
+            {
+                ["message"] = $"Error on Capture: {ret}",
+                ["success"] = false
+            }
+        );
+
+        APIServiceInstance._NBioAPI.GetTextFIRFromHandle(hCapturedFIR, out NBioAPI.Type.FIR_TEXTENCODE textFIR, true);
+
+        return new OkObjectResult(
+            new JsonObject
+            {
+                ["template"] = textFIR.TextFIR,
+                ["success"] = true
+            }
+        );
+    }
+
 }

--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ qualquer outra coisa:
 
 --------------------------------
 
+#### GET: `capture/`
+Ativa o dispositivo biométrico para capturar uma amostra apenas da impressão digital para verificação:  
+`200 | OK`
+```json
+{
+    "template": "AAAAAZCXZDSfe34t4f//...",  <------- fingerprint hash
+    "success": true
+}
+```
+qualquer outra coisa:  
+`400 | BAD REQUEST`
+```json
+{
+    "message": "Error on Capture: {nitgen error code}",
+    "success": false
+}
+```
+
+--------------------------------
+
 #### POST: `match-one-on-one/`
 Recebe um template e ativa o dispositivo biométrico para comparar:  
 ##### conteúdo da requisição POST:


### PR DESCRIPTION
No antigo projeto FingertechWEB existia a rota `/api/public/v1/captura/Capturar/1` que permitia a coleta de uma única digital com o objetivo de fazer uma verificação 1:1.

O BiometricServiceAPI realiza a captura simples na rota `http://localhost:5000/apiservice/match-one-on-one/` porém ele captura e já faz o teste contra um FIR previamente fornecido sem retornar o template capturado, apenas dá o resultado OK / não OK.

Proponho incluir na API a possibilidade capturar uma única amostra de digital com esta PR e permitir que o próprio usuário faça a própria validação, para manter compatibilidade com projetos legados.